### PR TITLE
Added check for successful fetch of data before concatenating results

### DIFF
--- a/src/components/DashboardPanel/DashboardPanel.js
+++ b/src/components/DashboardPanel/DashboardPanel.js
@@ -91,7 +91,10 @@ export default class DashboardPanel extends Component {
     // Must return only a single array of data, for dygraph to paint, so concatenate results
     let finalData = [];
     resultList.forEach((rawData) => {
-      finalData = finalData.concat(rawData.data.results);
+      // Check results have returned properly - service returns false if error
+      if (rawData.success === true) {
+        finalData = finalData.concat(rawData.data.results);
+      }
     });
     // give an initial parse-through based on the first value then use it to
     // populate the toggle map. Initial parse-through is necessary to populate


### PR DESCRIPTION
Related to [Issue #20](https://github.com/Edds390/solarnetwork-aggregated-dashboard/issues/20).

Added a simple conditional to check if results have come back successfully from API call.

NOTE: This shouldn't be an issue as a non-existent node shouldn't be provided under a real project. However, added a check just in case. 
____

**Changes:**
- Issue where the 'results' key value was being accessed when it did not exist, thus throwing an error. Added a simple conditional check to see if the success key value is 'true'. If it is, access the 'results' key value and concatenates to the finalData array. If it is false, skips/ignores the node.